### PR TITLE
fix: False positives when remove called before add events.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@buildertrend/eslint-plugin-enterprise-extras",
   "description": "Extra eslint rules for enterprise environments focusing on React and Typescript",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/rules/unregister-events.ts
+++ b/src/rules/unregister-events.ts
@@ -3,7 +3,7 @@ import { ESLintUtils, TSESTree } from "@typescript-eslint/experimental-utils";
 type MessageIds = "unregisterEventsInClass" | "unregisterEventsInHook";
 type Options = [];
 
-interface ISubscriptionStack {
+interface ISubscription {
   callExpression: TSESTree.Node;
   eventHandler: TSESTree.Node;
   eventName: string;
@@ -32,12 +32,10 @@ export default ESLintUtils.RuleCreator(
   },
   defaultOptions: [],
   create: function (context) {
-    let stack: ISubscriptionStack[] = [];
+    let addedSubscriptions: ISubscription[] = [];
+    let removedSubscriptions: ISubscription[] = [];
 
-    const isSameSubscription = (
-      sub1: ISubscriptionStack,
-      sub2: ISubscriptionStack
-    ) => {
+    const isSameSubscription = (sub1: ISubscription, sub2: ISubscription) => {
       if (sub1.eventName === sub2.eventName) {
         const handler1Tokens = context
           .getSourceCode()
@@ -56,25 +54,34 @@ export default ESLintUtils.RuleCreator(
       return false;
     };
 
-    const clearStack = () => {
-      stack = [];
+    const clearSubscriptionTracking = () => {
+      addedSubscriptions = [];
+      removedSubscriptions = [];
     };
 
-    const reportStack = (componentType: "hook" | "classComponent") => {
-      stack.forEach((error) => {
-        context.report({
-          node: error.callExpression,
-          messageId:
-            componentType === "classComponent"
-              ? "unregisterEventsInClass"
-              : "unregisterEventsInHook",
+    const reportSubscriptionsMissingRemoveCalls = (
+      componentType: "hook" | "classComponent"
+    ) => {
+      addedSubscriptions
+        .filter((addedSubscription) => {
+          return !removedSubscriptions.some((removedSubscription) =>
+            isSameSubscription(addedSubscription, removedSubscription)
+          );
+        })
+        .forEach((error) => {
+          context.report({
+            node: error.callExpression,
+            messageId:
+              componentType === "classComponent"
+                ? "unregisterEventsInClass"
+                : "unregisterEventsInHook",
+          });
         });
-      });
 
-      clearStack();
+      clearSubscriptionTracking();
     };
 
-    const pushStack = (callExpression: TSESTree.CallExpression) => {
+    const pushAddSubscription = (callExpression: TSESTree.CallExpression) => {
       // If the callExpression fails these checks, chances are you have compiler errors anyways, so we can ignore adding to the stack
       if (
         callExpression.arguments.length >= 2 &&
@@ -92,12 +99,14 @@ export default ESLintUtils.RuleCreator(
             eventHandler: handler,
             callExpression: callExpression,
           };
-          stack.push(subscription);
+          addedSubscriptions.push(subscription);
         }
       }
     };
 
-    const popStack = (callExpression: TSESTree.CallExpression) => {
+    const pushRemoveSubscription = (
+      callExpression: TSESTree.CallExpression
+    ) => {
       // If the callExpression fails these checks, chances are you have compiler errors anyways, so we can ignore adding to the stack
       if (
         callExpression.arguments.length >= 2 &&
@@ -111,72 +120,73 @@ export default ESLintUtils.RuleCreator(
           typeof eventType.value === "string"
         ) {
           const eventName = eventType.value;
-          const subscription: ISubscriptionStack = {
+          const subscription: ISubscription = {
             callExpression: callExpression,
             eventName: eventName,
             eventHandler: handler,
           };
 
-          stack = stack.filter((existingSubscription) => {
-            return !isSameSubscription(subscription, existingSubscription);
-          });
+          removedSubscriptions.push(subscription);
         }
       }
     };
 
     return {
-      // Clear the stack between files to avoid memory leaks
-      Program: clearStack,
-      "Program:exit": clearStack,
+      // Clear the subscription tracking lists between files to avoid memory leaks
+      Program: clearSubscriptionTracking,
+      "Program:exit": clearSubscriptionTracking,
 
-      // Add event listener registrations made in class components to the stack
+      // Track event listener registrations made in class components
       "ClassDeclaration[superClass.property.name=/Component|PureComponent/] CallExpression[callee.name='addEventListener']":
-        pushStack,
+        pushAddSubscription,
       "ClassDeclaration[superClass.property.name=/Component|PureComponent/] CallExpression[callee.object.name=/window|document/][callee.property.name='addEventListener']":
-        pushStack,
+        pushAddSubscription,
 
-      // Remove event listeners from the stack in class component componentWillUnmount methods
+      // Track remove event listener calls in class component componentWillUnmount methods
       "ClassDeclaration[superClass.property.name=/Component|PureComponent/] MethodDefinition[key.name='componentWillUnmount'] CallExpression[callee.object.name=/window|document/][callee.property.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "ClassDeclaration[superClass.property.name=/Component|PureComponent/] MethodDefinition[key.name='componentWillUnmount'] CallExpression[callee.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "ClassDeclaration[superClass.property.name=/Component|PureComponent/] ClassProperty[key.name='componentWillUnmount'] CallExpression[callee.object.name=/window|document/][callee.property.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "ClassDeclaration[superClass.property.name=/Component|PureComponent/] ClassProperty[key.name='componentWillUnmount'] CallExpression[callee.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
 
-      // Add event listener registrations made in hook components to the stack
+      // Track event listener registrations made in hook components
       "VariableDeclarator[id.name=/^[A-Z].+/] CallExpression[callee.name='addEventListener']":
-        pushStack,
+        pushAddSubscription,
       "VariableDeclarator[id.name=/^[A-Z].+/] CallExpression[callee.object.name=/window|document/][callee.property.name='addEventListener']":
-        pushStack,
+        pushAddSubscription,
       "FunctionDeclaration[id.name=/^[A-Z].+/] CallExpression[callee.name='addEventListener']":
-        pushStack,
+        pushAddSubscription,
       "FunctionDeclaration[id.name=/^[A-Z].+/] CallExpression[callee.object.name=/window|document/][callee.property.name='addEventListener']":
-        pushStack,
+        pushAddSubscription,
 
-      // Remove event listeners from the stack in hook component useEffect cleanups
+      // Track remove event listener calls in hook component useEffect cleanups
       "VariableDeclarator[id.name=/^[A-Z].+/] CallExpression[callee.name='useEffect'] > ArrowFunctionExpression ReturnStatement CallExpression[callee.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "VariableDeclarator[id.name=/^[A-Z].+/] CallExpression[callee.name='useEffect'] > ArrowFunctionExpression ReturnStatement CallExpression[callee.object.name=/window|document/][callee.property.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "VariableDeclarator[id.name=/^[A-Z].+/] CallExpression[callee.object.name='React'][callee.property.name='useEffect'] > ArrowFunctionExpression ReturnStatement CallExpression[callee.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "VariableDeclarator[id.name=/^[A-Z].+/] CallExpression[callee.object.name='React'][callee.property.name='useEffect'] > ArrowFunctionExpression ReturnStatement CallExpression[callee.object.name=/window|document/][callee.property.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "FunctionDeclaration[id.name=/^[A-Z].+/] CallExpression[callee.name='useEffect'] > ArrowFunctionExpression ReturnStatement CallExpression[callee.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "FunctionDeclaration[id.name=/^[A-Z].+/] CallExpression[callee.name='useEffect'] > ArrowFunctionExpression ReturnStatement CallExpression[callee.object.name=/window|document/][callee.property.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "FunctionDeclaration[id.name=/^[A-Z].+/] CallExpression[callee.object.name='React'][callee.property.name='useEffect'] > ArrowFunctionExpression ReturnStatement CallExpression[callee.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
       "FunctionDeclaration[id.name=/^[A-Z].+/] CallExpression[callee.object.name='React'][callee.property.name='useEffect'] > ArrowFunctionExpression ReturnStatement CallExpression[callee.object.name=/window|document/][callee.property.name='removeEventListener']":
-        popStack,
+        pushRemoveSubscription,
 
       // Report any event listeners not unregistered and still in the stack when leaving a class component/hook
-      "VariableDeclarator[id.name=/^[A-Z].+/]:exit": () => reportStack("hook"),
-      "FunctionDeclaration[id.name=/^[A-Z].+/]:exit": () => reportStack("hook"),
-      "ClassDeclaration:exit": () => reportStack("classComponent"),
+      "VariableDeclarator[id.name=/^[A-Z].+/]:exit": () =>
+        reportSubscriptionsMissingRemoveCalls("hook"),
+      "FunctionDeclaration[id.name=/^[A-Z].+/]:exit": () =>
+        reportSubscriptionsMissingRemoveCalls("hook"),
+      "ClassDeclaration:exit": () =>
+        reportSubscriptionsMissingRemoveCalls("classComponent"),
     };
   },
 });

--- a/tests/rules/unregister-events.test.ts
+++ b/tests/rules/unregister-events.test.ts
@@ -8,6 +8,9 @@ const ruleTester = new ESLintUtils.RuleTester({
     ecmaVersion: 2018,
     tsconfigRootDir: join(__dirname, "../fixtures"),
     project: "./tsconfig.json",
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
 });
 
@@ -206,6 +209,32 @@ ruleTester.run("unregister-events", rule, {
         })
 
         return null;
+      }
+    `,
+    `
+      const MyComponent: React.FC = () => {
+        useEffect(() => {
+          return () => {
+            removeEventListener("scroll", handler);
+          }
+        })
+
+        return <div onClick={() => addEventListener("scroll", handler)} />;
+      }
+    `,
+    `
+      class MyComponent extends React.Component {
+        private handler = () => {
+
+        };
+
+        componentWillUnmount() {
+          window.removeEventListener("scroll", handler);
+        }
+
+        render() {
+          return <div onClick={() => addEventListener("scroll", handler)} />;
+        }
       }
     `,
   ],


### PR DESCRIPTION
Fixed an issue where `removeEventListener` calls that were made _before_ `addEventListener` calls caused the rule to report false positives.