### PR TITLE
feature/no-unstable-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module.exports = {
 | [private-component-methods](/docs/private-component-methods.md)  | ✅ | 🔧 | Requires that all methods of react components are private (except reserved lifecycle methods) |
 | [no-unhandled-scheduling](/docs/no-unhandled-scheduling.md)  | ✅ |  | `setTimeout` and `setInterval` calls should be cleared |
 | [unregister-events](/docs/unregister-events.md)  | ✅ |  | Ensures all events registered in React components are unregistered when component unmounts |
+| [no-unstable-dependencies](/docs/no-unstable-dependencies.md)  | ✅ |  | Helps find dependencies that are used in React hook dependency arrays that will change values every time the component render is called |
 
 ## LICENSE
 

--- a/docs/no-unstable-dependencies.md
+++ b/docs/no-unstable-dependencies.md
@@ -1,0 +1,65 @@
+# Prevents the use of variables with unstable values in React hook dependencies (`no-unstable-dependencies`)
+
+Unstable dependencies should be avoided in React hook dependency arrays. This rule helps find dependencies that are used in React hook dependency arrays
+that will change values every time the component render is called, such as when they are set to a new instance of an object, array, or function.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+class MyClass {}
+const MyBadComponent: React.FC<any> = ({myInstance = new MyClass()}) => {
+  React.useEffect(() => {}, [myInstance]);
+}
+
+const MyBadComponent2: React.FC<any> = ({myObject = {}}) => {
+  React.useEffect(() => {}, [myObject]);
+}
+
+const MyBadComponent3: React.FC<any> = ({myArray = []}) => {
+  React.useEffect(() => {}, [myArray]);
+}
+
+const MyBadComponent4: React.FC<any> = () => {
+  const myFunction = () => {
+    alert("Hello");
+  };
+  React.useEffect(() => {}, [myFunction]);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+class MyClass {}
+const defaultInstance = new MyClass();
+const MyGoodComponent: React.FC<any> = ({myInstance = defaultInstance}) => {
+  React.useEffect(() => {}, [myInstance]);
+}
+
+const defaultObject = {};
+const MyGoodComponent2: React.FC<any> = ({myObject = defaultObject}) => {
+  React.useEffect(() => {}, [myObject]);
+}
+
+const defaultArray = [];
+const MyGoodComponent3: React.FC<any> = ({myArray = defaultArray}) => {
+  React.useEffect(() => {}, [myArray]);
+}
+
+const MyGoodComponent4: React.FC<any> = () => {
+  const myFunction = React.useMemo(() => {
+
+  });
+  React.useEffect(() => {}, [myFunction]);
+}
+```
+
+## When Not To Use It
+
+False positives, or when constant/stable values in things like parameter defaults are not desired.
+
+## Auto-fixable?
+
+No ❌

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import noHrefAssignment from "./rules/no-href-assignment";
 import noUnhandledScheduling from "./rules/no-unhandled-scheduling";
 import privateComponentMethods from "./rules/private-component-methods";
 import unregisterEvents from "./rules/unregister-events";
-import preventUnstableDependencies from "./rules/prevent-unstable-dependencies";
+import noUnstableDependencies from "./rules/no-unstable-dependencies";
 
 export = {
   rules: {
@@ -10,7 +10,7 @@ export = {
     "private-component-methods": privateComponentMethods,
     "no-unhandled-scheduling": noUnhandledScheduling,
     "unregister-events": unregisterEvents,
-    "prevent-unstable-dependencies": preventUnstableDependencies,
+    "no-unstable-dependencies": noUnstableDependencies,
   },
   configs: {
     recommended: {
@@ -20,7 +20,7 @@ export = {
         "enterprise-extras/private-component-methods": "error",
         "enterprise-extras/no-unhandled-scheduling": "warn",
         "enterprise-extras/unregister-events": "error",
-        "enterprise-extras/prevent-unstable-dependencies": "warn",
+        "enterprise-extras/no-unstable-dependencies": "warn",
       },
     },
     all: {
@@ -30,7 +30,7 @@ export = {
         "enterprise-extras/private-component-methods": "error",
         "enterprise-extras/no-unhandled-scheduling": "error",
         "enterprise-extras/unregister-events": "error",
-        "enterprise-extras/prevent-unstable-dependencies": "error",
+        "enterprise-extras/no-unstable-dependencies": "error",
       },
     },
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import noHrefAssignment from "./rules/no-href-assignment";
 import noUnhandledScheduling from "./rules/no-unhandled-scheduling";
 import privateComponentMethods from "./rules/private-component-methods";
 import unregisterEvents from "./rules/unregister-events";
+import preventUnstableDependencies from "./rules/prevent-unstable-dependencies";
 
 export = {
   rules: {
@@ -9,6 +10,7 @@ export = {
     "private-component-methods": privateComponentMethods,
     "no-unhandled-scheduling": noUnhandledScheduling,
     "unregister-events": unregisterEvents,
+    "prevent-unstable-dependencies": preventUnstableDependencies,
   },
   configs: {
     recommended: {
@@ -18,6 +20,7 @@ export = {
         "enterprise-extras/private-component-methods": "error",
         "enterprise-extras/no-unhandled-scheduling": "warn",
         "enterprise-extras/unregister-events": "error",
+        "enterprise-extras/prevent-unstable-dependencies": "warn",
       },
     },
     all: {
@@ -27,6 +30,7 @@ export = {
         "enterprise-extras/private-component-methods": "error",
         "enterprise-extras/no-unhandled-scheduling": "error",
         "enterprise-extras/unregister-events": "error",
+        "enterprise-extras/prevent-unstable-dependencies": "error",
       },
     },
   },

--- a/src/rules/no-unstable-dependencies.ts
+++ b/src/rules/no-unstable-dependencies.ts
@@ -53,19 +53,21 @@ export default ESLintUtils.RuleCreator(
                   depReferenceDefinitions &&
                   depReferenceDefinitions.length > 0
                 ) {
-                  const writeReferences = depReference.resolved.references
+                  const writeReferences = depReference.resolved?.references
                     .filter((ref) => ref.isWrite() && ref.writeExpr)
                     .map((ref) => ref.writeExpr);
 
                   // If every known write expression is unstable, then we know that the variable is not save to use as a react hook dependency
                   if (
+                    writeReferences &&
+                    writeReferences.length > 0 &&
                     writeReferences.every((writeReference) =>
-                      isUnstableExpression(writeReference)
+                      isUnstableExpression(writeReference!)
                     )
                   ) {
                     writeReferences.forEach((writeReference) => {
                       context.report({
-                        node: writeReference,
+                        node: writeReference!,
                         messageId: "unstableDependency",
                       });
                     });

--- a/src/rules/no-unstable-dependencies.ts
+++ b/src/rules/no-unstable-dependencies.ts
@@ -17,7 +17,7 @@ export default ESLintUtils.RuleCreator(
   (name) =>
     `https://github.com/buildertrend/eslint-plugin-enterprise-extras/blob/main/docs/${name}.md`
 )<Options, MessageIds>({
-  name: "prevent-unstable-dependencies",
+  name: "no-unstable-dependencies",
   meta: {
     type: "suggestion",
     fixable: "code",

--- a/src/rules/no-unstable-dependencies.ts
+++ b/src/rules/no-unstable-dependencies.ts
@@ -24,7 +24,7 @@ export default ESLintUtils.RuleCreator(
     docs: {
       recommended: "error",
       description:
-        "Unstable dependencies should be avoided in React functional component dependency arrays",
+        "Unstable dependencies should be avoided in React hook dependency arrays",
     },
     messages: {
       unstableDependency:
@@ -35,23 +35,13 @@ export default ESLintUtils.RuleCreator(
   defaultOptions: [],
   create: function (context) {
     const reportUnstableDeps = (useHookCall: TSESTree.CallExpression) => {
-      if (useHookCall.arguments[1].type == "ArrayExpression") {
+      if (useHookCall.arguments[1].type === "ArrayExpression") {
         const scope = context.getScope();
 
         useHookCall.arguments[1].elements.forEach((dependency) => {
-          let depIdentifier: undefined | TSESTree.Identifier = undefined;
           if (isIdentifier(dependency)) {
-            depIdentifier = dependency;
-          } else if (
-            isMemberExpression(dependency) &&
-            isIdentifier(dependency.object)
-          ) {
-            depIdentifier = dependency.object;
-          }
-
-          if (depIdentifier) {
             const depReference = scope.references.find(
-              (ref) => ref.identifier === depIdentifier
+              (ref) => ref.identifier === dependency
             );
 
             if (depReference) {
@@ -78,6 +68,10 @@ export default ESLintUtils.RuleCreator(
                         node: writeReference,
                         messageId: "unstableDependency",
                       });
+                    });
+                    context.report({
+                      node: dependency,
+                      messageId: "unstableDependency",
                     });
                   }
                 }

--- a/src/rules/prevent-unstable-dependencies.ts
+++ b/src/rules/prevent-unstable-dependencies.ts
@@ -1,0 +1,98 @@
+import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+import {
+  isFunctionDeclaration,
+  isIdentifier,
+  isMemberExpression,
+  isMethod,
+  isUnstableAssignment,
+  isUnstableExpression,
+} from "../utils/type-guards";
+
+type MessageIds = "unstableDependency";
+type Options = [];
+
+const hooksWithDependenciesRegex = "use(Callback|Memo|Effect)";
+
+export default ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/buildertrend/eslint-plugin-enterprise-extras/blob/main/docs/${name}.md`
+)<Options, MessageIds>({
+  name: "prevent-unstable-dependencies",
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    docs: {
+      recommended: "error",
+      description:
+        "Unstable dependencies should be avoided in React functional component dependency arrays",
+    },
+    messages: {
+      unstableDependency:
+        "Variable is created every render, but it is used in a React hook dependency array. Consider moving the value to a module constant.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create: function (context) {
+    const reportUnstableDeps = (useHookCall: TSESTree.CallExpression) => {
+      if (useHookCall.arguments[1].type == "ArrayExpression") {
+        const scope = context.getScope();
+
+        useHookCall.arguments[1].elements.forEach((dependency) => {
+          let depIdentifier: undefined | TSESTree.Identifier = undefined;
+          if (isIdentifier(dependency)) {
+            depIdentifier = dependency;
+          } else if (
+            isMemberExpression(dependency) &&
+            isIdentifier(dependency.object)
+          ) {
+            depIdentifier = dependency.object;
+          }
+
+          if (depIdentifier) {
+            const depReference = scope.references.find(
+              (ref) => ref.identifier === depIdentifier
+            );
+
+            if (depReference) {
+              const depReferenceScope = depReference.from;
+
+              if (isFunctionDeclaration(depReferenceScope.block)) {
+                const depReferenceDefinitions = depReference.resolved?.defs;
+                if (
+                  depReferenceDefinitions &&
+                  depReferenceDefinitions.length > 0
+                ) {
+                  const writeReferences = depReference.resolved.references
+                    .filter((ref) => ref.isWrite() && ref.writeExpr)
+                    .map((ref) => ref.writeExpr);
+
+                  // If every known write expression is unstable, then we know that the variable is not save to use as a react hook dependency
+                  if (
+                    writeReferences.every((writeReference) =>
+                      isUnstableExpression(writeReference)
+                    )
+                  ) {
+                    writeReferences.forEach((writeReference) => {
+                      context.report({
+                        node: writeReference,
+                        messageId: "unstableDependency",
+                      });
+                    });
+                  }
+                }
+              }
+            }
+          }
+        });
+      }
+    };
+
+    return {
+      [`CallExpression[arguments.length>=2][callee.type="MemberExpression"][callee.property.type="Identifier"][callee.property.name=/${hooksWithDependenciesRegex}/]`]:
+        reportUnstableDeps,
+      [`CallExpression[arguments.length>=2][callee.type="Identifier"][callee.name=/${hooksWithDependenciesRegex}/]`]:
+        reportUnstableDeps,
+    };
+  },
+});

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -57,13 +57,17 @@ const setOfUnstableAssignmentTypes = new Set([
   "ArrayExpression",
   "ArrowFunctionExpression",
   "FunctionExpression",
+  "JSXElement",
+  "JSXFragment",
 ]);
 type UnstableExpression =
   | TSESTree.NewExpression
   | TSESTree.ObjectExpression
   | TSESTree.ArrayExpression
   | TSESTree.ArrowFunctionExpression
-  | TSESTree.FunctionExpression;
+  | TSESTree.FunctionExpression
+  | TSESTree.JSXElement
+  | TSESTree.JSXFragment;
 export const isUnstableExpression = (
   node: TSESTree.Node
 ): node is UnstableExpression => {

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -24,14 +24,71 @@ export const isMethod = (
   );
 };
 
+export const isFunctionDeclaration = (
+  node: TSESTree.Node
+): node is TSESTree.ArrowFunctionExpression | TSESTree.FunctionDeclaration => {
+  return (
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "FunctionDeclaration"
+  );
+};
+
 export const isIdentifier = (
   node: TSESTree.Expression | TSESTree.PrivateIdentifier
 ): node is TSESTree.Identifier => {
   return node.type === "Identifier";
 };
 
+export const isMemberExpression = (
+  node: TSESTree.Expression
+): node is TSESTree.MemberExpression => {
+  return node.type === "MemberExpression";
+};
+
 export const isAsExpression = (
   node: TSESTree.Expression
 ): node is TSESTree.TSAsExpression => {
   return node.type === "TSAsExpression";
+};
+
+const setOfUnstableAssignmentTypes = new Set([
+  "NewExpression",
+  "ObjectExpression",
+  "ArrayExpression",
+  "ArrowFunctionExpression",
+  "FunctionExpression",
+]);
+type UnstableExpression =
+  | TSESTree.NewExpression
+  | TSESTree.ObjectExpression
+  | TSESTree.ArrayExpression
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionExpression;
+export const isUnstableExpression = (
+  node: TSESTree.Node
+): node is UnstableExpression => {
+  return setOfUnstableAssignmentTypes.has(node.type);
+};
+
+export const isAssignmentPattern = (
+  node: TSESTree.Node
+): node is TSESTree.AssignmentPattern => {
+  return node.type === "AssignmentPattern";
+};
+
+export const isVariableDeclarator = (
+  node: TSESTree.Node
+): node is TSESTree.VariableDeclarator => {
+  return node.type === "VariableDeclarator";
+};
+
+export const isUnstableAssignment = (node: TSESTree.Node) => {
+  let expression: null | TSESTree.Expression = null;
+  if (isAssignmentPattern(node)) {
+    expression = node.right;
+  } else if (isVariableDeclarator(node)) {
+    expression = node.init;
+  }
+
+  return expression && isUnstableExpression(expression);
 };

--- a/tests/rules/no-unstable-dependencies.test.ts
+++ b/tests/rules/no-unstable-dependencies.test.ts
@@ -1,0 +1,206 @@
+import rule from "../../src/rules/no-unstable-dependencies";
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { resolve, join } from "path";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: resolve("./node_modules/@typescript-eslint/parser") as any,
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, "../fixtures"),
+    project: "./tsconfig.json",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run("no-unstable-dependencies", rule, {
+  valid: [
+    `
+      class MyHandler {}
+      interface MyProps {
+        handler?: MyHandler;
+      }
+      const defaultHandler = new MyHandler();
+      const MyComponent: React.FC<MyProps> = ({handler = defaultHandler}) => {
+        React.useEffect(() => {}, [handler]);
+      }
+    `,
+    `      
+      interface MyProps {
+        myNum?: number;
+      }
+      const MyComponent: React.FC<MyProps> = ({myNum = 432}) => {
+        React.useEffect(() => {}, [handler]);
+      }
+    `,
+    `
+      interface MyProps {
+        myString?: string;
+      }
+      const MyComponent: React.FC<MyProps> = ({myString = "123"}) => {
+        React.useEffect(() => {}, [myString]);
+      }
+    `,
+    `
+      class MyHandler {}
+      interface MyProps {
+        handler?: MyHandler | string;
+      }
+      const MyComponent: React.FC = ({handler = new MyHandler()}) => {
+        handler = "";
+        React.useEffect(() => {}, [handler]);
+      }
+    `,
+  ],
+
+  invalid: [
+    {
+      code: `
+        class MyHandler {}
+        interface MyProps {
+          handler?: MyHandler;
+        }
+        const MyComponent: React.FC<MyProps> = ({handler = new MyHandler()}) => {
+          React.useEffect(() => {}, [handler]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
+    {
+      code: `
+        interface MyProps {
+          myComponent?: React.Element;
+        }
+        const MyComponent: React.FC<MyProps> = ({myComponent = <></>}) => {
+          React.useEffect(() => {}, [myComponent]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
+    {
+      code: `
+        interface MyProps {
+          myComponent?: React.Element;
+        }
+        const MyComponent: React.FC<MyProps> = ({myComponent = <div></div>}) => {
+          React.useEffect(() => {}, [myComponent]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
+    {
+      code: `
+        interface MyProps {
+          myHandler?: () => void;
+        }
+        const MyComponent: React.FC<MyProps> = ({myHandler = () => {}}) => {
+          React.useEffect(() => {}, [myHandler]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
+    {
+      code: `
+        const MyComponent: React.FC<any> = () => {
+          const myFunction = () => {};
+          React.useEffect(() => {}, [myFunction]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
+    {
+      code: `
+        interface MyProps {
+          myObj?: {};
+        }
+        const MyComponent: React.FC<MyProps> = ({myObj = {}}) => {
+          React.useEffect(() => {}, [myObj]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
+    {
+      code: `
+        interface MyProps {
+          myArray?: number[];
+        }
+        const MyComponent: React.FC<MyProps> = ({myArray = []}) => {
+          React.useEffect(() => {}, [myArray]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
+    {
+      code: `
+        interface MyProps {
+          myArray?: number[];
+        }
+        const MyComponent: React.FC<MyProps> = ({myArray = []}) => {
+          myArray = [123];
+          React.useEffect(() => {}, [myArray]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
+  ],
+});

--- a/tests/rules/no-unstable-dependencies.test.ts
+++ b/tests/rules/no-unstable-dependencies.test.ts
@@ -26,6 +26,14 @@ ruleTester.run("no-unstable-dependencies", rule, {
         React.useEffect(() => {}, [handler]);
       }
     `,
+    `
+      interface MyProps {
+        handler: object;
+      }
+      const MyComponent: React.FC<MyProps> = ({handler}) => {
+        React.useEffect(() => {}, [handler]);
+      }
+    `,
     `      
       interface MyProps {
         myNum?: number;


### PR DESCRIPTION
Unstable dependencies should be avoided in React hook dependency arrays. This rule helps find dependencies that are used in React hook dependency arrays
that will change values every time the component render is called, such as when they are set to a new instance of an object, array, or function.