### PR TITLE
feature/require-typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module.exports = {
 | [private-component-methods](/docs/private-component-methods.md)  | ✅ | 🔧 | Requires that all methods of react components are private (except reserved lifecycle methods) |
 | [no-unhandled-scheduling](/docs/no-unhandled-scheduling.md)  | ✅ |  | `setTimeout` and `setInterval` calls should be cleared |
 | [unregister-events](/docs/unregister-events.md)  | ✅ |  | Ensures all events registered in React components are unregistered when component unmounts |
+| [require-typography](/docs/require-typography.md)  | ✅ | 🔧 (Partially) | Require usage of smart quotes and other typographic unicode characters |
 
 ## LICENSE
 

--- a/docs/require-typography.md
+++ b/docs/require-typography.md
@@ -1,0 +1,27 @@
+# Require usage of smart quotes and other typographic unicode characters (`require-typography`)
+
+This rule requires that all string literals or JSX text elements use typographic alternatives. For example, "smart quotes" -> “smart quotes” get converted. Ellipsis (... -> …) and the plus or minus symbol conversions (+- -> ±) are also required under this rule.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+"Testing testing... '123' +-100";
+'The quick brown "fox"';
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+"Testing testing… ‘123’ ±100";
+'The quick brown “fox”';
+```
+
+## When Not To Use It
+
+If you have many strings that are not human readable, and therefore should use the typographic alternatives.
+
+## Auto-fixable?
+
+Some 🟨

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@buildertrend/eslint-plugin-enterprise-extras",
   "description": "Extra eslint rules for enterprise environments focusing on React and Typescript",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@buildertrend/eslint-plugin-enterprise-extras",
   "description": "Extra eslint rules for enterprise environments focusing on React and Typescript",
-  "version": "4.0.0",
+  "version": "3.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import noHrefAssignment from "./rules/no-href-assignment";
 import noUnhandledScheduling from "./rules/no-unhandled-scheduling";
 import privateComponentMethods from "./rules/private-component-methods";
 import unregisterEvents from "./rules/unregister-events";
+import requireTypography from "./rules/require-typography";
 
 export = {
   rules: {
@@ -9,6 +10,7 @@ export = {
     "private-component-methods": privateComponentMethods,
     "no-unhandled-scheduling": noUnhandledScheduling,
     "unregister-events": unregisterEvents,
+    "require-typography": requireTypography,
   },
   configs: {
     recommended: {
@@ -18,6 +20,7 @@ export = {
         "enterprise-extras/private-component-methods": "error",
         "enterprise-extras/no-unhandled-scheduling": "warn",
         "enterprise-extras/unregister-events": "error",
+        "enterprise-extras/require-typography": "error",
       },
     },
     all: {
@@ -27,6 +30,7 @@ export = {
         "enterprise-extras/private-component-methods": "error",
         "enterprise-extras/no-unhandled-scheduling": "error",
         "enterprise-extras/unregister-events": "error",
+        "enterprise-extras/require-typography": "error",
       },
     },
   },

--- a/src/rules/require-typography.ts
+++ b/src/rules/require-typography.ts
@@ -1,0 +1,346 @@
+import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+import { RuleContext } from "@typescript-eslint/utils/dist/ts-eslint";
+
+type MessageIds = "requireTypography";
+type ConversionType = "html" | "unicode" | "ascii";
+
+type Options = [
+  {
+    preferAscii: boolean;
+  }
+];
+const optionDefaults: Options = [
+  {
+    preferAscii: false,
+  },
+];
+
+interface ITypographicConversionBase {
+  name: string;
+  characterRegex: RegExp;
+  report: (
+    context: Readonly<RuleContext<"requireTypography", Options>>,
+    conversionType: ConversionType,
+    sourceText: string,
+    sourceStartIndex: number
+  ) => void;
+}
+
+interface IStandardConversion extends ITypographicConversionBase {
+  unicode: string;
+  ascii: string;
+  html: string;
+  sourceErrorSize: number;
+}
+
+interface ISmartQuoteConversion extends ITypographicConversionBase {
+  leftUnicodeQuote: string;
+  leftAsciiQuote: string;
+  leftHtmlQuote: string;
+  rightUnicodeQuote: string;
+  rightAsciiQuote: string;
+  rightHtmlQuote: string;
+}
+
+interface ISmartQuoteReportContext {
+  context: Readonly<RuleContext<"requireTypography", Options>>;
+  conversion: ISmartQuoteConversion;
+  conversionType: ConversionType;
+  sourceText: string;
+  sourceStartIndex: number;
+}
+
+const whiteSpaceRegex = /\s/g;
+const reportSmartQuote = ({
+  conversion,
+  context,
+  conversionType,
+  sourceText,
+  sourceStartIndex,
+}: ISmartQuoteReportContext) => {
+  const matches = [...sourceText.matchAll(conversion.characterRegex)];
+
+  matches.forEach((match) => {
+    const matchTextIndex = match.index ?? 0;
+    let unicodeQuote = conversion.rightUnicodeQuote;
+    let asciiQuote = conversion.rightAsciiQuote;
+    let htmlQuote = conversion.rightHtmlQuote;
+    let isFixable = true;
+
+    let useLeftQuote = false;
+    if (matchTextIndex === 0) {
+      isFixable = false;
+    } else if (whiteSpaceRegex.test(sourceText[matchTextIndex - 1])) {
+      useLeftQuote = true;
+    }
+
+    if (useLeftQuote) {
+      unicodeQuote = conversion.leftUnicodeQuote;
+      asciiQuote = conversion.leftAsciiQuote;
+      htmlQuote = conversion.leftHtmlQuote;
+    }
+
+    let toText;
+    switch (conversionType) {
+      case "ascii":
+        toText = asciiQuote;
+        break;
+      case "html":
+        toText = htmlQuote;
+        break;
+      default:
+        toText = unicodeQuote;
+        break;
+    }
+
+    const reportStart = sourceStartIndex + matchTextIndex;
+    const reportEnd = reportStart + 1;
+
+    context.report({
+      messageId: "requireTypography",
+      data: {
+        toUnicode: isFixable
+          ? unicodeQuote
+          : `${conversion.leftUnicodeQuote} OR ${conversion.rightUnicodeQuote}`,
+        toAsciiAlternate: unicodeQuote === toText ? "" : ` [${toText}]`,
+      },
+      loc: {
+        start: context.getSourceCode().getLocFromIndex(reportStart),
+        end: context.getSourceCode().getLocFromIndex(reportEnd),
+      },
+      fix: isFixable
+        ? function (fixer) {
+            return fixer.replaceTextRange([reportStart, reportEnd], toText);
+          }
+        : undefined,
+    });
+  });
+};
+
+interface IStandardReportContext {
+  context: Readonly<RuleContext<"requireTypography", Options>>;
+  conversion: IStandardConversion;
+  conversionType: ConversionType;
+  sourceText: string;
+  sourceStartIndex: number;
+}
+const reportStandard = ({
+  conversion,
+  context,
+  conversionType,
+  sourceText,
+  sourceStartIndex,
+}: IStandardReportContext) => {
+  const matches = [...sourceText.matchAll(conversion.characterRegex)];
+
+  matches.forEach((match) => {
+    const matchIndex = match.index ?? 0;
+
+    let toText: string;
+    switch (conversionType) {
+      case "ascii":
+        toText = conversion.ascii;
+        break;
+      case "html":
+        toText = conversion.html;
+        break;
+      default:
+        toText = conversion.unicode;
+        break;
+    }
+
+    const reportStart = sourceStartIndex + matchIndex;
+    const reportEnd = reportStart + conversion.sourceErrorSize;
+
+    context.report({
+      messageId: "requireTypography",
+      data: {
+        toUnicode: conversion.unicode,
+        toAsciiAlternate: conversion.unicode === toText ? "" : ` [${toText}]`,
+      },
+      loc: {
+        start: context.getSourceCode().getLocFromIndex(reportStart),
+        end: context.getSourceCode().getLocFromIndex(reportEnd),
+      },
+      fix(fixer) {
+        return fixer.replaceTextRange([reportStart, reportEnd], toText);
+      },
+    });
+  });
+};
+
+const conversions: ITypographicConversionBase[] = [
+  {
+    name: "singleQuote",
+    characterRegex: /'/g,
+    leftUnicodeQuote: "‘",
+    leftAsciiQuote: "\\u2018",
+    leftHtmlQuote: "&lsquo;",
+    rightUnicodeQuote: "’",
+    rightAsciiQuote: "\\u2019",
+    rightHtmlQuote: "&rsquo;",
+    report(context, conversionType, sourceText, sourceStartIndex) {
+      reportSmartQuote({
+        conversion: this,
+        context,
+        conversionType,
+        sourceText,
+        sourceStartIndex,
+      });
+    },
+  } as ISmartQuoteConversion,
+  {
+    name: "doubleQuote",
+    characterRegex: /"/g,
+    leftUnicodeQuote: "“",
+    leftAsciiQuote: "\\u201C",
+    leftHtmlQuote: "&ldquo;",
+    rightUnicodeQuote: "”",
+    rightAsciiQuote: "\\u201D",
+    rightHtmlQuote: "&rdquo;",
+    report(context, conversionType, sourceText, sourceStartIndex) {
+      reportSmartQuote({
+        conversion: this,
+        context,
+        conversionType,
+        sourceText,
+        sourceStartIndex,
+      });
+    },
+  } as ISmartQuoteConversion,
+  {
+    name: "ellipsis",
+    characterRegex: /\.\.\./g,
+    sourceErrorSize: 3,
+    unicode: "…",
+    ascii: "\\u2026",
+    html: "&hellip;",
+    report(context, conversionType, sourceText, sourceStartIndex) {
+      reportStandard({
+        conversion: this,
+        context,
+        conversionType,
+        sourceText,
+        sourceStartIndex,
+      });
+    },
+  } as IStandardConversion,
+  {
+    name: "plusOrMinus",
+    characterRegex: /\+\-/g,
+    unicode: "±",
+    ascii: "\\u{B1}",
+    html: "&plusmn;",
+    sourceErrorSize: 2,
+    report(context, conversionType, sourceText, sourceStartIndex) {
+      reportStandard({
+        conversion: this,
+        context,
+        conversionType,
+        sourceText,
+        sourceStartIndex,
+      });
+    },
+  } as IStandardConversion,
+];
+
+export default ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/buildertrend/eslint-plugin-enterprise-extras/blob/main/docs/${name}.md`
+)<Options, MessageIds>({
+  name: "require-typography",
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    docs: {
+      recommended: "error",
+      description:
+        "Prefer using the alternative typographic characters for human readable text",
+    },
+    messages: {
+      requireTypography:
+        "Prefer using the alternative typographic character {{ toUnicode }}{{ toAsciiAlternate }}",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          preferAscii: {
+            default: optionDefaults[0].preferAscii,
+            type: "boolean",
+          },
+        },
+      },
+    ],
+  },
+  defaultOptions: optionDefaults,
+  create: function (context) {
+    const preferAscii = { ...optionDefaults, ...context.options[0] }
+      .preferAscii;
+
+    const combinedRegexSource = conversions
+      .map(
+        (conversion, index) =>
+          `(?<c${index}>${conversion.characterRegex.source})`
+      )
+      .join("|");
+    const combinedRegex = new RegExp(combinedRegexSource, "g");
+
+    const processTypography = (
+      sourceText: string,
+      sourceStartIndex: number,
+      conversionType: ConversionType
+    ) => {
+      if (combinedRegex.test(sourceText)) {
+        combinedRegex.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        const setOfConversionIndicesToRun = new Set<number>();
+        while ((match = combinedRegex.exec(sourceText)) !== null) {
+          Object.keys(match.groups)
+            .filter(
+              (groupKey) => groupKey.startsWith("c") && !!match.groups[groupKey]
+            )
+            .map((groupKey) => parseInt(groupKey.substring(1)))
+            .forEach((val) => setOfConversionIndicesToRun.add(val));
+        }
+
+        if (setOfConversionIndicesToRun.size > 0) {
+          Array.from(setOfConversionIndicesToRun).forEach((conversionIndex) => {
+            conversions[conversionIndex].report(
+              context,
+              conversionType,
+              sourceText,
+              sourceStartIndex
+            );
+          });
+        }
+      }
+    };
+
+    return {
+      Literal: (literal: TSESTree.Literal) => {
+        if (typeof literal.value === "string") {
+          processTypography(
+            literal.raw.substring(1, literal.raw.length - 1),
+            literal.range[0] + 1,
+            preferAscii ? "ascii" : "unicode"
+          );
+        }
+      },
+      TemplateElement: (templateText: TSESTree.TemplateElement) => {
+        processTypography(
+          templateText.value.raw,
+          templateText.range[0] + 1,
+          preferAscii ? "html" : "unicode"
+        );
+      },
+      JSXText: (jsxText: TSESTree.JSXText) => {
+        processTypography(
+          jsxText.raw,
+          jsxText.range[0],
+          preferAscii ? "html" : "unicode"
+        );
+      },
+    };
+  },
+});

--- a/tests/rules/require-typography.test.ts
+++ b/tests/rules/require-typography.test.ts
@@ -1,0 +1,224 @@
+import rule from "../../src/rules/require-typography";
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { resolve, join } from "path";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: resolve("./node_modules/@typescript-eslint/parser") as any,
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, "../fixtures"),
+    project: "./tsconfig.json",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run("require-typography", rule, {
+  valid: [
+    `
+      "’";
+    `,
+    `
+      <>’</>;
+    `,
+    `
+      \`’\`;
+    `,
+    `
+      "‘";
+    `,
+    `
+      "”";
+    `,
+    `
+      "“";
+    `,
+    `
+      "…";
+    `,
+    `
+      "±";
+    `,
+  ],
+
+  invalid: [
+    {
+      code: `
+        "there's"
+      `,
+      output: `
+        "there’s"
+      `,
+      errors: [
+        {
+          messageId: "requireTypography",
+        },
+      ],
+    },
+    {
+      code: `
+        "'hello'"
+      `,
+      output: `
+        "'hello’"
+      `,
+      errors: [
+        {
+          messageId: "requireTypography",
+        },
+        {
+          messageId: "requireTypography",
+        },
+      ],
+    },
+    {
+      code: `
+        <>fdfas 'hello'</>
+      `,
+      output: `
+        <>fdfas ‘hello’</>
+      `,
+      errors: [
+        {
+          messageId: "requireTypography",
+        },
+        {
+          messageId: "requireTypography",
+        },
+      ],
+    },
+    {
+      code: `
+        const test = \`'\${123}'\`;
+      `,
+      output: `
+        const test = \`'\${123}'\`;
+      `,
+      errors: [
+        {
+          messageId: "requireTypography",
+        },
+        {
+          messageId: "requireTypography",
+        },
+      ],
+    },
+    {
+      code: `
+        ' "hello"';
+      `,
+      output: `
+        ' “hello”';
+      `,
+      errors: [
+        {
+          messageId: "requireTypography",
+        },
+        {
+          messageId: "requireTypography",
+        },
+      ],
+    },
+    {
+      code: `
+        "Loading...";
+      `,
+      output: `
+        "Loading…";
+      `,
+      errors: [
+        {
+          messageId: "requireTypography",
+        },
+      ],
+    },
+    {
+      code: `
+      import React from "react";
+
+      interface IState {
+        isLoaded: boolean;
+      }
+
+      class MyComponent extends React.Component<{}, IState> {
+        state: Readonly<IState> = {
+          isLoaded: false,
+        };
+
+        componentDidMount() {
+          void setTimeout(() => {
+            this.setState({ isLoaded: true });
+          }, 1000);
+        }
+
+        render() {
+          const loadingText = "You're currently waiting for your service to load...";
+
+          if (!this.state.isLoaded) {
+            return loadingText;
+          }
+
+          return (
+            <>
+              Hello, and welcome to "MyComponent"! There are around +- 300 people
+              visiting this page at the moment.
+            </>
+          );
+        }
+      }
+      `,
+      output: `
+      import React from "react";
+
+      interface IState {
+        isLoaded: boolean;
+      }
+
+      class MyComponent extends React.Component<{}, IState> {
+        state: Readonly<IState> = {
+          isLoaded: false,
+        };
+
+        componentDidMount() {
+          void setTimeout(() => {
+            this.setState({ isLoaded: true });
+          }, 1000);
+        }
+
+        render() {
+          const loadingText = "You’re currently waiting for your service to load…";
+
+          if (!this.state.isLoaded) {
+            return loadingText;
+          }
+
+          return (
+            <>
+              Hello, and welcome to “MyComponent”! There are around ± 300 people
+              visiting this page at the moment.
+            </>
+          );
+        }
+      }
+      `,
+      errors: [
+        {
+          messageId: "requireTypography",
+        },
+        {
+          messageId: "requireTypography",
+        },
+        {
+          messageId: "requireTypography",
+        },
+        {
+          messageId: "requireTypography",
+        },
+        {
+          messageId: "requireTypography",
+        },
+      ],
+    },
+  ],
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "lib": ["ESNext"],
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -12,7 +13,8 @@
     "skipLibCheck": true,
     "sourceMap": false,
     "suppressImplicitAnyIndexErrors": true,
-    "declaration": true
+    "declaration": true,
+    "downlevelIteration": true
   },
   "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
This rule requires that all string literals or JSX text elements use typographic alternatives. For example, "smart quotes" -> “smart quotes” get converted. Ellipsis (... -> …) and the plus or minus symbol conversions (+- -> ±) are also required under this rule.