### PR TITLE
fix/no-unstable-dependencies reporting dup errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "/dist"
   ],
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.10.0",
-    "@typescript-eslint/parser": "^5.10.0",
-    "eslint": "^7.32.0"
+    "@typescript-eslint/eslint-plugin": "5.10.0",
+    "@typescript-eslint/parser": "5.10.0",
+    "eslint": "7.32.0"
   },
   "devDependencies": {
     "@types/node": "14.14.35",
@@ -21,7 +21,9 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "eslint": "^7"
+    "eslint": "^7",
+    "@typescript-eslint/eslint-plugin": "^5",
+    "@typescript-eslint/parser": "^5"
   },
   "scripts": {
     "clean": "rimraf dist/",

--- a/tests/rules/no-unstable-dependencies.test.ts
+++ b/tests/rules/no-unstable-dependencies.test.ts
@@ -210,5 +210,53 @@ ruleTester.run("no-unstable-dependencies", rule, {
         },
       ],
     },
+    {
+      code: `
+        interface MyProps {
+          myArray?: number[];
+        }
+        const MyComponent: React.FC<MyProps> = ({myArray = []}) => {
+          React.useEffect(() => {}, [myArray]);
+          React.useEffect(() => {}, [myArray]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
+    {
+      code: `
+        interface MyProps {
+          myArray?: number[];
+        }
+        const MyComponent: React.FC<MyProps> = ({myArray = []}) => {
+          myArray = [123];
+          React.useEffect(() => {}, [myArray]);
+          React.useEffect(() => {}, [myArray]);
+        }
+      `,
+      errors: [
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+        {
+          messageId: "unstableDependency",
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
If an unstable variable is used in multiple hooks, we were previously reporting multiple errors for the same variable causing some minor lint error pollution