### PR TITLE
No Deprecated Element Patches

### DIFF
--- a/docs/no-deprecated-element.md
+++ b/docs/no-deprecated-element.md
@@ -1,15 +1,15 @@
 # Flag and replace deprecated component usage (`no-deprecated-element`)
 
-This rule allows you to flag a specific jsx element as deprecated, and optionally offer a replacement. Advanced configuration can be used with this rule to enable additional metaprogramming that can add/translate/remove props from the deprecated component to the new component
+This rule allows you to flag a specific jsx element as deprecated, and optionally offer a replacement. Advanced configuration can be used with this rule to enable additional meta-programming that can add/translate/remove props from the deprecated component to the new component
 
 ## Rule Details
 
-A majority of how this rule works comes down to the configuration. It simply allows you to blacklist a specific element, and optionally offer a replacement element.
+A majority of how this rule works comes down to the configuration. It simply allows you to blacklist a specific element, and optionally offer a replacement element. 
 
-> For now, this simply replaces the element name, without adjusting props or imports for a given file. 
+> This plugin does not adjust imports for a given file. 
 
 ```json
-"enterprise-extras/no-deprecated-element": [
+"@buildertrend/enterprise-extras/no-deprecated-element": [
     "warn",
     {
         deprecate: [
@@ -61,7 +61,7 @@ In the case that the new component just adds/removes or translates a few props f
 
 Here is an example configuration demonstrating this:
 ```javascript
-"enterprise-extras/no-deprecated-element": [
+"@buildertrend/enterprise-extras/no-deprecated-element": [
     "warn",
     {
         deprecate: [
@@ -83,10 +83,10 @@ Here is an example configuration demonstrating this:
                       // the defaultValue for the prop is used instead
                       keysToPullValueFrom: ["name"],
 
-                      // Tells the autofixer to NOT override the
+                      // Tells the autofixer to NOT overwrite the
                       // prop if a prop with the same name already exists
                       // on the deprecated component 
-                      override: false
+                      overwrite: false
                     },
                     {
                       key: "data-testid",
@@ -94,7 +94,7 @@ Here is an example configuration demonstrating this:
                       // Can pull values from multiple keys if desired in order of
                       // priority
                       keysToPullValueFrom: ["id", "name"],
-                      override: true
+                      overwrite: true
                     },
                   ],
                   // Remove any props in this array AFTER any props are added
@@ -131,13 +131,13 @@ Example using the advanced configuration above to translate an old component to 
 }
 ```
 
-**NOTE:** Autofixing is experimental. In addition, it does not handle formatting automatically. Using an opinionated formatter, like Prettier, is highly recommended to resolve non-symantic issues (extra spaces) with the fixer.
+**NOTE:** Autofixing is experimental. In addition, it does not handle formatting automatically. Using an opinionated formatter, like Prettier, is highly recommended to resolve non-semantic issues (extra spaces) with the fixer.
 
 ## When Not To Use It
 
 Don't use this if you don't have elements you are looking to deprecate or have cleaned up all existing usages.
 
-Don't use this for complicated metaprogramming while replacing a component beyond adding props, removing props, or translating/renaming props. For these even more complex deprecations, consider creating a separate linting plugin that can handle these more advanced, or programatic use cases.
+Don't use this for complicated meta-programming while replacing a component beyond adding props, removing props, or translating/renaming props. For these even more complex deprecations, consider creating a separate linting plugin that can handle these more advanced, or programmatic use cases.
 ## Auto-fixable?
 
 Yes ✔️

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@buildertrend/eslint-plugin-enterprise-extras",
   "description": "Extra eslint rules for enterprise environments focusing on React and Typescript",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/rules/no-deprecated-element.ts
+++ b/src/rules/no-deprecated-element.ts
@@ -179,14 +179,6 @@ export default ESLintUtils.RuleCreator(
             messageId: "noDeprecatedElement",
             data: deprecation,
           });
-
-          if (closingIdentifier !== undefined) {
-            context.report({
-              node: closingIdentifier,
-              messageId: "noDeprecatedElement",
-              data: deprecation,
-            });
-          }
           return;
         }
 
@@ -281,18 +273,6 @@ export default ESLintUtils.RuleCreator(
             replaceElement: replacement.element,
           },
         });
-
-        if (closingIdentifier !== undefined) {
-          context.report({
-            node: closingIdentifier,
-            messageId: "noDeprecatedElement_replacement",
-            fix: replacementFixer,
-            data: {
-              element: deprecation.element,
-              replaceElement: replacement.element,
-            },
-          });
-        }
       },
     };
   },

--- a/tests/rules/no-deprecated-element.test.ts
+++ b/tests/rules/no-deprecated-element.test.ts
@@ -107,9 +107,6 @@ ruleTester.run("no-deprecated-element", rule, {
         {
           messageId: "noDeprecatedElement_replacement",
         },
-        {
-          messageId: "noDeprecatedElement_replacement",
-        },
       ],
     },
     {
@@ -120,9 +117,6 @@ ruleTester.run("no-deprecated-element", rule, {
         {
           messageId: "noDeprecatedElement_replacement",
         },
-        {
-          messageId: "noDeprecatedElement_replacement",
-        },
       ],
     },
     {
@@ -130,9 +124,6 @@ ruleTester.run("no-deprecated-element", rule, {
       output: `<Parent.GoodElement prop="test">WithChildren</Parent.GoodElement>`,
       options: optionsReplace,
       errors: [
-        {
-          messageId: "noDeprecatedElement_replacement",
-        },
         {
           messageId: "noDeprecatedElement_replacement",
         },
@@ -174,9 +165,6 @@ ruleTester.run("no-deprecated-element", rule, {
         {
           messageId: "noDeprecatedElement",
         },
-        {
-          messageId: "noDeprecatedElement",
-        },
       ],
     },
     {
@@ -186,18 +174,12 @@ ruleTester.run("no-deprecated-element", rule, {
         {
           messageId: "noDeprecatedElement",
         },
-        {
-          messageId: "noDeprecatedElement",
-        },
       ],
     },
     {
       code: `<Parent.BadElement prop="test">WithChildren</Parent.BadElement>`,
       options: optionsNoReplace,
       errors: [
-        {
-          messageId: "noDeprecatedElement",
-        },
         {
           messageId: "noDeprecatedElement",
         },


### PR DESCRIPTION
- fix spelling and configuration examples
- remove closing element reporting

Reporting on both the opening and the closing elements caused difficulties when trying to disable the rule for valid use cases. Changed to only reporting on the opening element.

![image](https://user-images.githubusercontent.com/9992362/223141884-b2fc630b-6b8b-439e-8b22-a668bc39427b.png)
